### PR TITLE
Add missing bracket in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -623,7 +623,7 @@
                   <div class="panel-body">
                     <ul class="list-group row module-list">
                       <li class="col-md-6 col-xs-12">Azure DevOps</li>
-                      <li class="col-md-6 col-xs-12">Jenkins/li>
+                      <li class="col-md-6 col-xs-12">Jenkins</li>
                       <li class="col-md-6 col-xs-12">GitLab</li>
                     </ul>
                   </div>


### PR DESCRIPTION
This is a fix for "Jenkins/li>" printed on real website